### PR TITLE
Runtime algorithm selection support

### DIFF
--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -1065,18 +1065,18 @@ ncclResult_t scclGetAllAlgoFromSCCLConfigAndSetComm(struct ncclComm* comm, const
       const char *path;
       NCCLCHECK(xmlGetAttrStr(node, "path", &path));
 
-      int hasMinsize = false;
-      NCCLCHECK(xmlAttrExists(node, "minsize", &hasMinsize));
-      int64_t minsize = 0;
-      if (hasMinsize) {
-        NCCLCHECK(xmlGetAttrInt64_t(node, "minsize", &minsize));
+      int hasMinBytes = false;
+      NCCLCHECK(xmlAttrExists(node, "minbytes", &hasMinBytes));
+      int64_t minBytes = 0;
+      if (hasMinBytes) {
+        NCCLCHECK(xmlGetAttrInt64_t(node, "minbytes", &minBytes));
       }
 
-      int hasMaxsize = false;
-      NCCLCHECK(xmlAttrExists(node, "maxsize", &hasMaxsize));
-      int64_t maxsize = -1; // Represents infinity
-      if (hasMaxsize) {
-        NCCLCHECK(xmlGetAttrInt64_t(node, "maxsize", &maxsize));
+      int hasMaxBytes = false;
+      NCCLCHECK(xmlAttrExists(node, "maxbytes", &hasMaxBytes));
+      int64_t maxBytes = -1; // Represents infinity
+      if (hasMaxBytes) {
+        NCCLCHECK(xmlGetAttrInt64_t(node, "maxbytes", &maxBytes));
       }
 
       int hasProtocol = false;
@@ -1096,8 +1096,8 @@ ncclResult_t scclGetAllAlgoFromSCCLConfigAndSetComm(struct ncclComm* comm, const
         NCCLCHECK(ncclRealloc(&comm->scclRegistrations, comm->nScclRegistrations));
         struct scclRegistration *scclReg = &comm->scclRegistrations[regIndex];
         scclReg->algoIndex = algoIndex;
-        scclReg->minsize = minsize;
-        scclReg->maxsize = maxsize;
+        scclReg->minBytes = minBytes;
+        scclReg->maxBytes = maxBytes;
         NCCLCHECK(scclProtocolStrToId(protocol, &scclReg->protocol));
       } else {
         WARN("SCCL: algorithm %s failed to initialize. Will be ignored.", path);

--- a/src/graph/topo.h
+++ b/src/graph/topo.h
@@ -140,6 +140,12 @@ ncclResult_t ncclTopoGetXmlFromGraphs(int ngraphs, struct ncclTopoGraph** graphs
 
 ncclResult_t ncclTopoGetCompCap(struct ncclTopoSystem* system, int* ccMin, int* ccMax);
 
+// SCCL get algorithms from XML file and set the communicator
+ncclResult_t scclGetAllAlgoFromXMLFilesAndSetComm(struct ncclComm* comm, const char* str);
+
+// Read SCCL config, get algorithms and set the communicator
+ncclResult_t scclGetAllAlgoFromSCCLConfigAndSetComm(struct ncclComm* comm, const char* str);
+
 static ncclResult_t ncclTopoIdToIndex(struct ncclTopoSystem* system, int type, int64_t id, int* index) {
   *index = -1;
   for (int i=0; i<system->nodes[type].count; i++) {

--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -297,7 +297,7 @@ ncclResult_t ncclTopoGetAlgoTime(struct ncclInfo* info, int algorithm, int proto
     if (comm->nScclRegistrations > 0) {
       for (int i = 0; i < comm->nScclRegistrations; ++i) {
         struct scclRegistration *reg = &comm->scclRegistrations[i];
-        if (reg->minsize <= info->nBytes && (info->nBytes < reg->maxsize || reg->maxsize == -1) && reg->protocol == protocol) {
+        if (reg->minBytes <= info->nBytes && (info->nBytes < reg->maxBytes || reg->maxBytes == -1) && reg->protocol == protocol) {
           struct scclAlgorithm* scclAlgo = &comm->scclAlgos[reg->algoIndex];
           if ((scclAlgo->isValid) && (scclAlgo->collectiveType == info->coll) && (info->inplace == scclAlgo->inPlace) && (scclAlgo->ngpus == info->comm->nRanks)
               && ((info->count % scclAlgo->nchunksPerLoop) == 0)) {

--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -198,7 +198,7 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
   }
   
   // Disable SCCL if SCCL_XML_FILES is not specified
-  if (!getenv("SCCL_XML_FILES")){
+  if (!getenv("SCCL_XML_FILES") && !getenv("SCCL_CONFIG")){
     algoEnable[NCCL_ALGO_SCCL] = 0;
   }
 

--- a/src/graph/xml.cc
+++ b/src/graph/xml.cc
@@ -841,3 +841,27 @@ ncclResult_t scclGetXmlAlgoFromFile(const char* xmlGraphFile, struct ncclXml* xm
   fclose(file);
   return ncclSuccess;
 }
+
+ncclResult_t scclConfigXmlLoad(FILE* file, struct ncclXml* xmlGraph, struct ncclXmlNode* head) {
+  NCCLCHECK(xmlLoadSub(file, xmlGraph, head, NULL, 1));
+  return ncclSuccess;
+}
+
+ncclResult_t scclConfigXmlScclAlgos(FILE* file, struct ncclXml* xmlGraph, struct ncclXmlNode* head) {
+  struct xmlHandler handlers[] = { { "load", scclConfigXmlLoad } };
+  NCCLCHECK(xmlLoadSub(file, xmlGraph, head, handlers, 1));
+  return ncclSuccess;
+}
+
+ncclResult_t scclGetXmlConfigFromFile(const char* xmlGraphFile, struct ncclXml* xml) {
+  FILE* file = fopen(xmlGraphFile, "r");
+  if (file == NULL) {
+    WARN("Could not open XML SCCL config file %s : %s", xmlGraphFile, strerror(errno));
+    return ncclSystemError;
+  }
+  struct xmlHandler handlers[] = { { "sccl_algos", scclConfigXmlScclAlgos } };
+  xml->maxIndex = 0;
+  NCCLCHECK(xmlLoadSub(file, xml, NULL, handlers, 1));
+  fclose(file);
+  return ncclSuccess;
+}

--- a/src/graph/xml.h
+++ b/src/graph/xml.h
@@ -44,6 +44,7 @@ ncclResult_t ncclTopoDumpXmlToFile(const char* xmlTopoFile, struct ncclXml* xml)
 #define NCCL_GRAPH_XML_VERSION 1
 ncclResult_t ncclTopoGetXmlGraphFromFile(const char* xmlGraphFile, struct ncclXml* xml);
 ncclResult_t scclGetXmlAlgoFromFile(const char* xmlGraphFile, struct ncclXml* xml);
+ncclResult_t scclGetXmlConfigFromFile(const char* xmlGraphFile, struct ncclXml* xml);
 
 /* Auto-detect functions */
 ncclResult_t ncclTopoFillGpu(struct ncclXml* xml, const char* busId, struct ncclXmlNode** gpuNode);

--- a/src/include/alloc.h
+++ b/src/include/alloc.h
@@ -37,6 +37,17 @@ static ncclResult_t ncclCalloc(T** ptr, size_t nelem) {
 }
 
 template <typename T>
+static ncclResult_t ncclRealloc(T** ptr, size_t nelem) {
+  void* p = realloc(*ptr, nelem*sizeof(T));
+  if (p == NULL) {
+    WARN("Failed to realloc %ld bytes", nelem*sizeof(T));
+    return ncclSystemError;
+  }
+  *ptr = (T*)p;
+  return ncclSuccess;
+}
+
+template <typename T>
 static ncclResult_t ncclCudaCalloc(T** ptr, size_t nelem) {
   CUDACHECK(cudaMalloc(ptr, nelem*sizeof(T)));
   CUDACHECK(cudaMemset(*ptr, 0, nelem*sizeof(T)));

--- a/src/include/comm.h
+++ b/src/include/comm.h
@@ -58,8 +58,8 @@ struct ncclRecvMem {
 
 struct scclRegistration {
   int algoIndex;
-  int64_t minsize;
-  int64_t maxsize;
+  int64_t minBytes;
+  int64_t maxBytes;
   int protocol;
 };
 

--- a/src/include/comm.h
+++ b/src/include/comm.h
@@ -56,11 +56,20 @@ struct ncclRecvMem {
   char buff[1]; // Actually larger than that
 };
 
+struct scclRegistration {
+  int algoIndex;
+  int64_t minsize;
+  int64_t maxsize;
+  int protocol;
+};
+
 struct ncclComm {
   struct ncclChannel channels[MAXCHANNELS];
   int numberOfSCCAlgorithms;
   struct scclAlgorithm scclAlgos[SCCL_MAX_NUM_ALGOS];
   struct scclAlgorithmShared scclAlgoShared;
+  struct scclRegistration *scclRegistrations;
+  int nScclRegistrations;
 
   struct ncclPeerInfo* peerInfo;
   struct ncclTopoSystem* topo;

--- a/src/include/graph.h
+++ b/src/include/graph.h
@@ -35,9 +35,6 @@ ncclResult_t ncclTopoCheckGdr(struct ncclTopoSystem* topo, int64_t busId, int ne
 // Set CPU affinity
 ncclResult_t ncclTopoSetAffinity(struct ncclTopoSystem* system, int rank);
 
-// SCCL get alirthm from XML file and set the communicator
-ncclResult_t scclGetAllAlgoFromXMLFilesAndSetComm(struct ncclComm* comm, const char* str);
-
 #define NCCL_TOPO_CPU_ARCH_X86 1
 #define NCCL_TOPO_CPU_ARCH_POWER 2
 #define NCCL_TOPO_CPU_ARCH_ARM 3


### PR DESCRIPTION
This PR complements the one here: https://github.com/microsoft/sccl/pull/5

This adds support for parsing SCCL configuration files like:
```
<sccl_algos>
  <load path="/tmp/tmpa7cxwru7" minsize="1000000" maxsize="1500000" proto="Simple"/>
  <load path="/tmp/tmpmh7sawi9" minsize="1500000" maxsize="1700001" proto="LL"/>
  <load path="/tmp/tmpcm8zuihd" minsize="1700001" maxsize="1000000001" proto="Simple"/>
</sccl_algos>
```
The path to the file is specified in an environment variable `SCCL_CONFIG`. The `load` elements specify algorithms to use in specific size ranges for their collective and the protocol to use in that range.

This feature does not replace `SCCL_XML_FILES`, both can be used at the same time. However, if `SCCL_CONFIG` is present, then no algorithms from `SCCL_XML_FILES` will be selected for standard NCCL collectives. `ncclCustomCollective` can still be used to access those algorithms.